### PR TITLE
Implement DeleteHandler with unit tests

### DIFF
--- a/aws-opsworkscm-server/manual-requests/delete-execute.json
+++ b/aws-opsworkscm-server/manual-requests/delete-execute.json
@@ -1,0 +1,20 @@
+{
+  "credentials": {
+    "AccessKeyId": "<TO_BE_ADDED>",
+    "SecretAccessKey": "<TO_BE_ADDED>",
+    "SessionToken": "<TO_BE_ADDED>"
+  },
+  "action": "DELETE",
+  "request": {
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "region": "us-east-1",
+    "desiredResourceState": {
+      "ServerName": "JollansChef2"
+    },
+    "logicalResourceIdentifier": "MyOpsWorksCMServer"
+  },
+  "callbackContext": {
+    "stabilizationStarted": false,
+    "stabilizationRetryTimes": 0
+  }
+}

--- a/aws-opsworkscm-server/manual-requests/delete-stabilize.json
+++ b/aws-opsworkscm-server/manual-requests/delete-stabilize.json
@@ -1,0 +1,20 @@
+{
+  "credentials": {
+    "AccessKeyId": "<TO_BE_ADDED>",
+    "SecretAccessKey": "<TO_BE_ADDED>",
+    "SessionToken": "<TO_BE_ADDED>"
+  },
+  "action": "DELETE",
+  "request": {
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "region": "us-east-1",
+    "desiredResourceState": {
+      "ServerName": "JollansChef2"
+    },
+    "logicalResourceIdentifier": "MyOpsWorksCMServer"
+  },
+  "callbackContext": {
+    "stabilizationStarted": true,
+    "stabilizationRetryTimes": 3
+  }
+}

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/DeleteHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/DeleteHandler.java
@@ -1,27 +1,145 @@
 package software.amazon.opsworkscm.server;
 
+import com.amazonaws.util.StringUtils;
+import software.amazon.awssdk.services.opsworkscm.OpsWorksCmClient;
+import software.amazon.awssdk.services.opsworkscm.model.DescribeServersResponse;
+import software.amazon.awssdk.services.opsworkscm.model.InvalidStateException;
+import software.amazon.awssdk.services.opsworkscm.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.opsworkscm.model.Server;
+import software.amazon.awssdk.services.opsworkscm.model.ServerStatus;
+import software.amazon.awssdk.services.opsworkscm.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.resource.IdentifierUtils;
 
 public class DeleteHandler extends BaseHandler<CallbackContext> {
 
+    public static final String SERVER_DELETION_FAILED_MESSAGE = "Server %s deletion has failed with reason: %s";
+    public static final String SERVER_OPERATION_STILL_IN_PROGRESS_MESSAGE = "Cannot delete the server '%s'. The current operation on the server is still in progress\\." +
+            " \\(Service: AWSOpsWorksCM; Status Code: 400; Error Code: ValidationException; Request ID: .*\\)";
+
+    AmazonWebServicesClientProxy proxy;
+    ResourceHandlerRequest<ResourceModel> request;
+    CallbackContext callbackContext;
+    Logger logger;
+    ResourceModel model;
+    ClientWrapper client;
+
+    private static int NO_CALLBACK_DELAY = 0;
+    private static int CALLBACK_DELAY_SECONDS = 60;
+    private static final int MAX_LENGTH_CONFIGURATION_SET_NAME = 40;
+
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        this.request = request;
+        this.model = request.getDesiredResourceState();
+        this.callbackContext = callbackContext;
+        this.logger = logger;
 
-        // TODO : put your code here
+        setModelServerName();
+        setModelId();
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+        final OpsWorksCmClient opsWorksCmClientclient = ClientBuilder.getClient();
+        this.client = new ClientWrapper(opsWorksCmClientclient, model, proxy, logger);
+
+        try {
+            if (callbackContext.isStabilizationStarted()) {
+                return handleStabilize();
+            } else {
+                return handleExecute();
+            }
+        } catch (InvalidStateException e) {
+            logger.log(String.format("Service Side failure during delete-server for %s.", model.getServerName()));
+            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.NotStabilized, "Service Internal Failure");
+        } catch (ResourceNotFoundException e) {
+            return handleServerNotFound(model.getServerName());
+        } catch (ValidationException e) {
+            if (e.getMessage().matches(String.format(SERVER_OPERATION_STILL_IN_PROGRESS_MESSAGE, model.getServerName()))) {
+                logger.log(String.format("Server operation still in progress during delete-server of %s.", model.getServerName()));
+                return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS, model);
+            }
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InvalidRequest);
+        } catch (Exception e) {
+            logger.log(String.format("CreateHandler failure during delete-server for %s.", model.getServerName()));
+            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InternalFailure, "Internal Failure");
+        }
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> handleExecute() {
+        client.deleteServer();
+        callbackContext.setStabilizationStarted(true);
+        return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS, model);
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> handleStabilize() {
+        final DescribeServersResponse result;
+        String serverName = model.getServerName();
+        callbackContext.incrementRetryTimes();
+
+        result = client.describeServer();
+
+        if (result == null || result.servers() == null) {
+            logger.log("Describe result is Null. Retrying request.");
+            return ProgressEvent.defaultInProgressHandler(callbackContext, NO_CALLBACK_DELAY, model);
+        }
+
+        if (result.servers().size() < 1) {
+            return handleServerNotFound(serverName);
+        }
+        Server server = result.servers().get(0);
+
+        ServerStatus serverStatus = server.status();
+        String statusReason = server.statusReason();
+        String actualServerName = server.serverName();
+
+        switch (serverStatus) {
+            case DELETING:
+                return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS, model);
+            case FAILED:
+                logger.log(String.format(SERVER_DELETION_FAILED_MESSAGE, actualServerName, statusReason));
+                return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.NotUpdatable, String.format(SERVER_DELETION_FAILED_MESSAGE, actualServerName, statusReason));
+            default:
+                logger.log(String.format("Server %s is in an unexpected state. Server should be deleted, but is %s. With reason: %s",
+                        actualServerName, serverStatus, statusReason));
+                return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS, model);
+        }
+    }
+
+    private void setModelServerName() {
+        if (StringUtils.isNullOrEmpty(model.getServerName())) {
+            model.setServerName(
+                    IdentifierUtils.generateResourceIdentifier(
+                            request.getLogicalResourceIdentifier(),
+                            request.getClientRequestToken(),
+                            MAX_LENGTH_CONFIGURATION_SET_NAME
+                    )
+            );
+        } else if (model.getServerName().length() > MAX_LENGTH_CONFIGURATION_SET_NAME) {
+            model.setServerName(model.getServerName().substring(0, MAX_LENGTH_CONFIGURATION_SET_NAME));
+        }
+    }
+
+    private void setModelId() {
+        if (model.getId() == null) {
+            model.setId(IdentifierUtils.generateResourceIdentifier(
+                    request.getLogicalResourceIdentifier(),
+                    request.getClientRequestToken()
+            ));
+        }
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> handleServerNotFound(final String serverName) {
+        logger.log(String.format("Server %s deleted successfully.", serverName));
+        return ProgressEvent.defaultSuccessHandler(model);
     }
 }

--- a/aws-opsworkscm-server/src/test/java/software/amazon/opsworkscm/server/DeleteHandlerTest.java
+++ b/aws-opsworkscm-server/src/test/java/software/amazon/opsworkscm/server/DeleteHandlerTest.java
@@ -1,17 +1,30 @@
 package software.amazon.opsworkscm.server;
 
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.opsworkscm.model.DeleteServerResponse;
+import software.amazon.awssdk.services.opsworkscm.model.DescribeServersResponse;
+import software.amazon.awssdk.services.opsworkscm.model.InvalidStateException;
+import software.amazon.awssdk.services.opsworkscm.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.opsworkscm.model.Server;
+import software.amazon.awssdk.services.opsworkscm.model.ValidationException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Collections;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,32 +36,317 @@ public class DeleteHandlerTest {
     @Mock
     private Logger logger;
 
+    DeleteHandler handler;
+    CallbackContext callbackContext;
+    ResourceModel model;
+    ResourceHandlerRequest<ResourceModel> request;
+
+    private static final String REGION = "us-east-1";
+    private static final String RESOURCE_IDENTIFIER = "MyOpsWorksCMServer";
+    private static final String SERVER_NAME = "ServerName";
+    private static final String ENGINE = "Chef";
+    private static final String ENGINE_VERSION = "12";
+    private static final String ENGINE_MODEL = "Single";
+    private static final String INSTANCE_TYPE = "m5.xlarge";
+    private static final String INSTANCE_PROFILE = "arn:aws:iam::012345678912:instance-profile/aws-opsworks-cm-ec2-role";
+    private static final String SERVICE_ROLE = "arn:aws:iam::012345678912:role/service-role/aws-opsworks-cm-service-role";
+
     @BeforeEach
     public void setup() {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
+
+        proxy = mock(AmazonWebServicesClientProxy.class);
+        logger = mock(Logger.class);
+        handler = new DeleteHandler();
+
+        callbackContext = CallbackContext.builder()
+                .stabilizationRetryTimes(0)
+                .stabilizationStarted(false)
+                .build();
+
+        model = ResourceModel.builder()
+                .serverName(SERVER_NAME)
+                .build();
+
+        request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .logicalResourceIdentifier(RESOURCE_IDENTIFIER)
+                .clientRequestToken(UUID.randomUUID().toString())
+                .region(REGION)
+                .build();
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        final DeleteHandler handler = new DeleteHandler();
+    public void testSimpleDelete() {
+        assertStabilizeSuccess(request);
+    }
 
+    @Test
+    public void testDeleteSimpleServerNoName() {
+        final String longResourceIdentifier = "OpsWorksCMServerHasAVeryLongResourceId";
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .desiredResourceState(model)
-            .build();
+                .desiredResourceState(model)
+                .logicalResourceIdentifier(longResourceIdentifier)
+                .clientRequestToken(UUID.randomUUID().toString())
+                .region(REGION)
+                .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response
-            = handler.handleRequest(proxy, request, null, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        ProgressEvent<ResourceModel, CallbackContext> response = assertStabilizeSuccess(request);
+        String actualServerName = response.getResourceModel().getServerName();
+        assertThat(actualServerName).startsWith(longResourceIdentifier.substring(0, 27) + "-");
+        assertThat(actualServerName.length()).isEqualTo(40);
     }
+
+    @Test
+    public void testDeleteSimpleServerAllCreateOptions() {
+        final ResourceModel model = ResourceModel.builder()
+                .serverName(SERVER_NAME)
+                .engine(ENGINE)
+                .engineVersion(ENGINE_VERSION)
+                .engineModel(ENGINE_MODEL)
+                .instanceProfileArn(INSTANCE_PROFILE)
+                .serviceRoleArn(SERVICE_ROLE)
+                .instanceType(INSTANCE_TYPE)
+                .keyPair("myKey")
+                .associatePublicIpAddress(true)
+                .backupRetentionCount(10)
+                .customCertificate("MyCert")
+                .customDomain("myDomain")
+                .preferredMaintenanceWindow("window")
+                .preferredBackupWindow("window2")
+                .securityGroupIds(Collections.singletonList("sg-123"))
+                .disableAutomatedBackup(true)
+                .endpoint("asd.com")
+                .tags(Collections.singletonList(Tag.builder().key("k").value("v").build()))
+                .engineAttributes(Collections.singletonList(EngineAttribute.builder().name("N").value("V").build()))
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .logicalResourceIdentifier(RESOURCE_IDENTIFIER)
+                .clientRequestToken(UUID.randomUUID().toString())
+                .region(REGION)
+                .build();
+
+        assertStabilizeSuccess(request);
+    }
+
+    @Test
+    public void testDeleteSimpleServerLongName() {
+        final ResourceModel model = ResourceModel.builder()
+                .serverName("OpsWorksCMServerHasAVeryLongServerNameInFactItIsTooLongBecauseTheMaxIsFourty")
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .logicalResourceIdentifier(RESOURCE_IDENTIFIER)
+                .clientRequestToken(UUID.randomUUID().toString())
+                .region(REGION)
+                .build();
+
+        ProgressEvent<ResourceModel, CallbackContext> response = assertStabilizeSuccess(request);
+        String actualServerName = response.getResourceModel().getServerName();
+        assertThat(actualServerName).isEqualTo("OpsWorksCMServerHasAVeryLongServerNameIn");
+        assertThat(actualServerName.length()).isEqualTo(40);
+    }
+
+    @Test
+    public void testExecuteResourceNotFound() {
+        doThrow(ResourceNotFoundException.builder().build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+    }
+
+    @Test
+    public void testStabilizeResourceNotFound() {
+        callbackContext.setStabilizationStarted(true);
+        doThrow(ResourceNotFoundException.builder().build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+    }
+
+    @Test
+    public void testStabilizeDescribeReturnsNoServers() {
+        callbackContext.setStabilizationStarted(true);
+        doReturn(DescribeServersResponse.builder().build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+    }
+
+    @Test
+    public void testExecuteOperationStillInProgress() {
+        doThrow(ValidationException.builder().message("Cannot delete the server '" + SERVER_NAME + "'. The current operation on the server is still in progress." +
+                " (Service: AWSOpsWorksCM; Status Code: 400; Error Code: ValidationException; Request ID: " + request.getClientRequestToken() + ")").build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+    }
+
+    @Test
+    public void testStabilizeOperationStillInProgress() {
+        callbackContext.setStabilizationStarted(true);
+        doThrow(ValidationException.builder().message("Cannot delete the server '" + SERVER_NAME + "'. The current operation on the server is still in progress." +
+                " (Service: AWSOpsWorksCM; Status Code: 400; Error Code: ValidationException; Request ID: " + request.getClientRequestToken() + ")").build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+
+    }
+
+    @Test
+    public void testExecuteValidationException() {
+        doThrow(ValidationException.builder().message("come on..").build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void testStabilizeValidationException() {
+        callbackContext.setStabilizationStarted(true);
+        doThrow(ValidationException.builder().message("come on..").build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void testStabilizeInvalidStateException() {
+        doThrow(InvalidStateException.builder().message("come on..").build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotStabilized);
+        assertThat(response.getMessage()).isEqualTo("Service Internal Failure");
+    }
+
+    @Test
+    public void testExecuteInvalidStateException() {
+        callbackContext.setStabilizationStarted(true);
+        doThrow(InvalidStateException.builder().message("come on..").build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotStabilized);
+        assertThat(response.getMessage()).isEqualTo("Service Internal Failure");
+    }
+
+    @Test
+    public void testExecuteUnknownException() {
+        doThrow(new ArrayIndexOutOfBoundsException("come on..")).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getMessage()).isEqualTo("Internal Failure");
+    }
+
+    @Test
+    public void testStabilizeUnknownException() {
+        callbackContext.setStabilizationStarted(true);
+        doThrow(new ArrayIndexOutOfBoundsException("come on..")).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InternalFailure);
+        assertThat(response.getMessage()).isEqualTo("Internal Failure");
+    }
+
+    @Test
+    public void testStabilizeRetryStatus() {
+        String[] transientStates = new String[]{"BACKING_UP", "MODIFYING", "RESTORING", "UNDER_MAINTENANCE", "CREATING", "DELETING", "CONNECTION_LOST", "TERMINATED"};
+        for (String state : transientStates) {
+            callbackContext = CallbackContext.builder()
+                    .stabilizationRetryTimes(0)
+                    .stabilizationStarted(false)
+                    .build();
+            assertStabilizeSuccess(state, request);
+        }
+    }
+
+    @Test
+    public void testStabilizeBadStatus() {
+        String state = "FAILED";
+        String statusReason = "customers fault";
+
+        doReturn(DeleteServerResponse.builder().build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> executeResponse
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(executeResponse).isNotNull();
+        assertThat(executeResponse.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+
+        doReturn(DescribeServersResponse.builder().servers(Server.builder().serverName(SERVER_NAME).status(state).statusReason(statusReason).build()).build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        ProgressEvent<ResourceModel, CallbackContext> stabilizeResponse
+                = handler.handleRequest(proxy, request, executeResponse.getCallbackContext(), logger);
+        assertThat(stabilizeResponse).isNotNull();
+        assertThat(stabilizeResponse.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(stabilizeResponse.getMessage()).isEqualTo("Server " + SERVER_NAME + " deletion has failed with reason: " + statusReason);
+        assertThat(stabilizeResponse.getErrorCode()).isEqualTo(HandlerErrorCode.NotUpdatable);
+    }
+
+    @Test
+    public void testStabilizeDescribeResultNull() {
+        callbackContext.setStabilizationStarted(true);
+        doReturn(null).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        ProgressEvent<ResourceModel, CallbackContext> stabilizeResponse
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(stabilizeResponse).isNotNull();
+        assertThat(stabilizeResponse.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(stabilizeResponse.getCallbackContext().getStabilizationRetryTimes()).isEqualTo(1);
+        assertThat(stabilizeResponse.getCallbackDelaySeconds()).isEqualTo(0);
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> assertStabilizeSuccess(ResourceHandlerRequest<ResourceModel> request) {
+        return assertStabilizeSuccess("DELETING", request);
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> assertStabilizeSuccess(String stabilizeStatus, ResourceHandlerRequest<ResourceModel> request) {
+        doReturn(DeleteServerResponse.builder().build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        final ProgressEvent<ResourceModel, CallbackContext> executeResponse
+                = handler.handleRequest(proxy, request, callbackContext, logger);
+        assertThat(executeResponse).isNotNull();
+        assertThat(executeResponse.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(executeResponse.getCallbackContext()).isNotNull();
+        assertThat(executeResponse.getCallbackContext().isStabilizationStarted()).isTrue();
+        assertThat(executeResponse.getCallbackContext().getStabilizationRetryTimes()).isEqualTo(0);
+        assertThat(executeResponse.getCallbackDelaySeconds()).isEqualTo(60);
+        assertThat(executeResponse.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(executeResponse.getResourceModels()).isNull();
+        assertThat(executeResponse.getMessage()).isNull();
+        assertThat(executeResponse.getErrorCode()).isNull();
+
+        doReturn(DescribeServersResponse.builder().servers(Server.builder().serverName(SERVER_NAME).status(stabilizeStatus).build()).build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        ProgressEvent<ResourceModel, CallbackContext> stabilizeResponse
+                = handler.handleRequest(proxy, request, executeResponse.getCallbackContext(), logger);
+        assertThat(stabilizeResponse).isNotNull();
+        assertThat(stabilizeResponse.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(stabilizeResponse.getCallbackContext()).isNotNull();
+        assertThat(stabilizeResponse.getCallbackContext().isStabilizationStarted()).isTrue();
+        assertThat(stabilizeResponse.getCallbackContext().getStabilizationRetryTimes()).isEqualTo(1);
+        assertThat(stabilizeResponse.getCallbackDelaySeconds()).isEqualTo(60);
+        assertThat(stabilizeResponse.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(stabilizeResponse.getResourceModels()).isNull();
+        assertThat(stabilizeResponse.getMessage()).isNull();
+        assertThat(stabilizeResponse.getErrorCode()).isNull();
+
+        doThrow(ResourceNotFoundException.builder().build()).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        stabilizeResponse = handler.handleRequest(proxy, request, executeResponse.getCallbackContext(), logger);
+        assertThat(stabilizeResponse).isNotNull();
+        assertThat(stabilizeResponse.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(stabilizeResponse.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(stabilizeResponse.getResourceModels()).isNull();
+        assertThat(stabilizeResponse.getMessage()).isNull();
+        assertThat(stabilizeResponse.getErrorCode()).isNull();
+
+        return executeResponse;
+    }
+
 }


### PR DESCRIPTION
Adding DeleteHandler and unit tests.

The handler duplicates some of code of the CreateHandler. Will take care of that later.

### Testing
* `mvn package`
* `sam local start-lambda` and tried the two jsons included in the pull request
