### PR TITLE
Fix Create and Delete bugs

### DIFF
--- a/aws-opsworkscm-server/aws-opsworkscm-server.json
+++ b/aws-opsworkscm-server/aws-opsworkscm-server.json
@@ -145,7 +145,7 @@
     "/properties/Engine"
   ],
   "primaryIdentifier": [
-    "/properties/Id"
+    "/properties/ServerName"
   ],
   "readOnlyProperties": [
     "/properties/Id",
@@ -155,29 +155,33 @@
   "handlers": {
     "create": {
       "permissions": [
-        "opsworkscm:ListReceiptFilters",
-        "opsworkscm:CreateReceiptFilter"
+        "opsworks-cm:CreateServer",
+        "opsworks-cm:DescribeServers",
+        "iam:PassRole"
       ]
     },
     "delete": {
       "permissions": [
-        "opsworkscm:ListReceiptFilters",
-        "opsworkscm:DeleteReceiptFilter"
+        "opsworks-cm:DeleteServer",
+        "opsworks-cm:DescribeServers"
       ]
     },
     "update": {
       "permissions": [
-        "opsworkscm:UpdateReceiptFilters"
+        "opsworks-cm:UpdateServer",
+        "opsworks-cm:TagResource",
+        "opsworks-cm:UntagResource",
+        "opsworks-cm:DescribeServers"
       ]
     },
     "list": {
       "permissions": [
-        "opsworkscm:ListReceiptFilters"
+        "opsworks-cm:DescribeServers"
       ]
     },
     "read": {
       "permissions": [
-        "opsworkscm:ListReceiptFilters"
+        "opsworks-cm:DescribeServers"
       ]
     }
   }

--- a/aws-opsworkscm-server/resource-role.yaml
+++ b/aws-opsworkscm-server/resource-role.yaml
@@ -23,10 +23,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - "opsworkscm:CreateReceiptFilter"
-                - "opsworkscm:DeleteReceiptFilter"
-                - "opsworkscm:ListReceiptFilters"
-                - "opsworkscm:UpdateReceiptFilters"
+                - "iam:PassRole"
+                - "opsworks-cm:CreateServer"
+                - "opsworks-cm:DeleteServer"
+                - "opsworks-cm:DescribeServers"
+                - "opsworks-cm:TagResource"
+                - "opsworks-cm:UntagResource"
+                - "opsworks-cm:UpdateServer"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/BaseOpsWorksCMHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/BaseOpsWorksCMHandler.java
@@ -37,7 +37,7 @@ abstract public class BaseOpsWorksCMHandler extends BaseHandler<CallbackContext>
         this.request = request;
         this.model = request.getDesiredResourceState();
         this.oldModel = request.getPreviousResourceState();
-        this.callbackContext = callbackContext;
+        this.callbackContext = callbackContext == null ? new CallbackContext() : callbackContext;
         this.log = new LoggerWrapper(logger);
 
         setModelServerName();
@@ -48,7 +48,9 @@ abstract public class BaseOpsWorksCMHandler extends BaseHandler<CallbackContext>
     }
 
     private void setModelServerName() {
-        if (StringUtils.isNullOrEmpty(model.getServerName())) {
+        if (oldModel != null && !StringUtils.isNullOrEmpty(oldModel.getServerName())) {
+            model.setServerName(oldModel.getServerName());
+        } else if (StringUtils.isNullOrEmpty(model.getServerName())) {
             log.log("RequestModel doesn't have the server name. Setting it using request identifier and client token");
             model.setServerName(
                     IdentifierUtils.generateResourceIdentifier(

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ClientWrapper.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ClientWrapper.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static software.amazon.opsworkscm.server.ResourceModel.IDENTIFIER_KEY_SERVERNAME;
+
 @AllArgsConstructor
 public class ClientWrapper {
 
@@ -35,8 +37,8 @@ public class ClientWrapper {
     AmazonWebServicesClientProxy proxy;
     LoggerWrapper log;
 
-    public DescribeServersResponse describeServer() {
-        return proxy.injectCredentialsAndInvokeV2(buildDescribeServerRequest(), client::describeServers);
+    public DescribeServersResponse describeServer(String serverName) {
+        return proxy.injectCredentialsAndInvokeV2(buildDescribeServerRequest(serverName), client::describeServers);
     }
 
     public DescribeServersResponse describeAllServers() {
@@ -71,9 +73,9 @@ public class ClientWrapper {
         return proxy.injectCredentialsAndInvokeV2(buildUpdateServerRequest(), client::updateServer);
     }
 
-    private DescribeServersRequest buildDescribeServerRequest() {
+    private DescribeServersRequest buildDescribeServerRequest(String serverName) {
         return DescribeServersRequest.builder()
-                .serverName(model.getServerName())
+                .serverName(serverName)
                 .build();
     }
     private DescribeServersRequest buildDescribeAllServersRequest() {
@@ -82,7 +84,7 @@ public class ClientWrapper {
 
     private DeleteServerRequest buildDeleteServerRequest() {
         return DeleteServerRequest.builder()
-                .serverName(model.getServerName())
+                .serverName(model.getPrimaryIdentifier().get(IDENTIFIER_KEY_SERVERNAME).toString())
                 .build();
     }
 
@@ -172,9 +174,9 @@ public class ClientWrapper {
     }
 
     private String getResourceArn() {
-        DescribeServersResponse describeServersResponse = describeServer();
+        DescribeServersResponse describeServersResponse = describeServer(model.getServerName());
         if (describeServersResponse != null && describeServersResponse.hasServers()) {
-            return describeServer().servers().get(0).serverArn();
+            return describeServer(model.getServerName()).servers().get(0).serverArn();
         }
         throw ResourceNotFoundException.builder().message(String.format("Server with name %s does not exist.", model.getServerName())).build();
     }

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/CreateHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/CreateHandler.java
@@ -24,17 +24,17 @@ public class CreateHandler extends BaseOpsWorksCMHandler {
         initialize(proxy, request, callbackContext, logger);
 
         try {
-            if (callbackContext.isStabilizationStarted()) {
+            if (this.callbackContext.isStabilizationStarted()) {
                 return handleStabilize();
             } else {
                 return handleExecute();
             }
         } catch (InvalidStateException e) {
-            log.error(String.format("Service Side failure during create-server for %s.", model.getServerName()), e);
-            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InternalFailure, "Service Internal Failure");
+            log.error(String.format("Service Side failure during create-server for %s.", this.model.getServerName()), e);
+            return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InternalFailure, "Service Internal Failure");
         } catch (Exception e) {
-            log.error(String.format("CreateHandler failure during create-server for %s.", model.getServerName()), e);
-            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InternalFailure, "Internal Failure");
+            log.error(String.format("CreateHandler failure during create-server for %s.", this.model.getServerName()), e);
+            return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InternalFailure, "Internal Failure");
         }
     }
 
@@ -55,7 +55,7 @@ public class CreateHandler extends BaseOpsWorksCMHandler {
         callbackContext.incrementRetryTimes();
 
         try {
-            result = client.describeServer();
+            result = client.describeServer(model.getServerName());
         } catch (final ResourceNotFoundException e) {
             return handleServerNotFound(serverName);
         }
@@ -82,6 +82,7 @@ public class CreateHandler extends BaseOpsWorksCMHandler {
             case RESTORING:
             case UNDER_MAINTENANCE:
             case CREATING:
+                log.info(String.format("Server %s is still creating.", actualServerName));
                 return ProgressEvent.defaultInProgressHandler(callbackContext, CALLBACK_DELAY_SECONDS, model);
             default:
                 log.info(String.format("Server %s failed to CREATE because of reason: %s", actualServerName, statusReason));

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ReadHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ReadHandler.java
@@ -8,6 +8,8 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.opsworkscm.server.ResourceModel.IDENTIFIER_KEY_SERVERNAME;
+
 public class ReadHandler extends BaseOpsWorksCMHandler {
 
     @Override
@@ -20,13 +22,13 @@ public class ReadHandler extends BaseOpsWorksCMHandler {
         initialize(proxy, request, callbackContext, logger);
 
         final DescribeServersResponse result;
-        final String serverName = model.getServerName();
+        final String serverName = model.getPrimaryIdentifier().get(IDENTIFIER_KEY_SERVERNAME).toString();
         callbackContext.incrementRetryTimes();
 
         log.info(String.format("Calling Describe Servers for ServerName %s", serverName));
 
         try {
-            result = client.describeServer();
+            result = client.describeServer(serverName);
             Server server = result.servers().get(0);
             addDescribeServerResponseAttributes(server);
             return ProgressEvent.defaultSuccessHandler(model);

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/UpdateHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/UpdateHandler.java
@@ -21,21 +21,21 @@ public class UpdateHandler extends BaseOpsWorksCMHandler {
         initialize(proxy, request, callbackContext, logger);
 
         try {
-            if (!callbackContext.isUpdateTagComplete()) {
+            if (!this.callbackContext.isUpdateTagComplete()) {
                 return updateTags();
             }
-            if (!callbackContext.isUpdateServerComplete()) {
+            if (!this.callbackContext.isUpdateServerComplete()) {
                 return updateServer();
             }
-            return ProgressEvent.defaultSuccessHandler(model);
+            return ProgressEvent.defaultSuccessHandler(this.model);
         } catch (ResourceNotFoundException e) {
-            log.error(String.format("ResourceNotFoundException during update of server %s, with message %s", model.getServerName(), e.getMessage()), e);
+            log.error(String.format("ResourceNotFoundException during update of server %s, with message %s", this.model.getServerName(), e.getMessage()), e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotFound);
         } catch (InvalidStateException e) {
-            log.error(String.format("InvalidStateException during update of server %s, with message %s", model.getServerName(), e.getMessage()), e);
+            log.error(String.format("InvalidStateException during update of server %s, with message %s", this.model.getServerName(), e.getMessage()), e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotUpdatable);
         } catch (ValidationException e) {
-            log.error(String.format("ValidationException during update of server %s, with message %s", model.getServerName(), e.getMessage()), e);
+            log.error(String.format("ValidationException during update of server %s, with message %s", this.model.getServerName(), e.getMessage()), e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InvalidRequest);
         }
     }

--- a/aws-opsworkscm-server/templates/opsworkscm-server.yaml
+++ b/aws-opsworkscm-server/templates/opsworkscm-server.yaml
@@ -8,8 +8,8 @@ Resources:
       Engine: 'ChefAutomate'
       EngineVersion: '2'
       EngineModel: 'Single'
-      InstanceProfileArn: "arn:aws:iam::<ACCOUNT_ID>:instance-profile/opsworks-cm-ec2-role"
+      InstanceProfileArn: "arn:aws:iam::<ACCOUNT_ID>:instance-profile/aws-opsworks-cm-ec2-role"
       InstanceType: 'm4.xlarge'
       PreferredBackupWindow: '08:00'
       PreferredMaintenanceWindow: 'Fri:08:00'
-      ServiceRoleArn: "arn:aws:iam::<ACCOUNT_ID>:role/opsworks-cm-service-role"
+      ServiceRoleArn: "arn:aws:iam::<ACCOUNT_ID>:role/service-role/aws-opsworks-cm-service-role"


### PR DESCRIPTION
Create and Delete had some bugs:
* In the initial call from CloudFormation the CallbackContext is
null. That case was not handled
* All operations were lacking permissions for opsworks-cm
* Delete did not get the correct serverName
  The serverName can be accessed with `model.getPrimaryIdentifier().get(IDENTIFIER_KEY_SERVERNAME).toString()`

### Testing:
* `mvn package`
* Tried out Create and Delete E2E for a simple happy case and both worked.
  ```
   cfn submit --region us-east-1 --set-default 
  aws cloudformation create-stack --stack-name testerstack-$RANDOM --template-body file://templates/opsworkscm-server.yaml
   ```