### PR TITLE
Forward ValidationException message to user

### DIFF
--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/CreateHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/CreateHandler.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.services.opsworkscm.model.ResourceAlreadyExistsExc
 import software.amazon.awssdk.services.opsworkscm.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.opsworkscm.model.Server;
 import software.amazon.awssdk.services.opsworkscm.model.ServerStatus;
+import software.amazon.awssdk.services.opsworkscm.model.ValidationException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -32,6 +33,9 @@ public class CreateHandler extends BaseOpsWorksCMHandler {
         } catch (InvalidStateException e) {
             log.error(String.format("Service Side failure during create-server for %s.", this.model.getServerName()), e);
             return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InternalFailure, "Service Internal Failure");
+        } catch (ValidationException e) {
+            log.error(String.format("ValidationException during create-server for %s.", this.model.getServerName()), e);
+            return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InvalidRequest, e.getMessage());
         } catch (Exception e) {
             log.error(String.format("CreateHandler failure during create-server for %s.", this.model.getServerName()), e);
             return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InternalFailure, "Internal Failure");

--- a/aws-opsworkscm-server/src/test/java/software/amazon/opsworkscm/server/DeleteHandlerTest.java
+++ b/aws-opsworkscm-server/src/test/java/software/amazon/opsworkscm/server/DeleteHandlerTest.java
@@ -206,6 +206,7 @@ public class DeleteHandlerTest {
                 = handler.handleRequest(proxy, request, callbackContext, logger);
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+        assertThat(response.getMessage()).isEqualTo("come on..");
     }
 
     @Test
@@ -216,6 +217,7 @@ public class DeleteHandlerTest {
                 = handler.handleRequest(proxy, request, callbackContext, logger);
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+        assertThat(response.getMessage()).isEqualTo("come on..");
     }
 
     @Test


### PR DESCRIPTION
Before we gave back ValidationExceptions as Internal Failure. This caused multiple issues:
1. The user cannot see what he did wrong.
2. If a resource already exists, then it will be deleted on the next attempt at creating it via cloudformation (the cfn creation fails with ResourceAlreadyExists, rolls back and deletes the existing resource)

Also added tests for DeleteServer, that ValidationException messages are passed to user.

### Testing
* mvn package
* manually created resource that already exists and saw that rollback did not delete the already existing resource
* pre-commit run --all-files
