### PR TITLE
Forward all OpsWorksCmException thrown by opworks-cm

### DIFF
--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/CreateHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/CreateHandler.java
@@ -2,6 +2,7 @@ package software.amazon.opsworkscm.server;
 
 import software.amazon.awssdk.services.opsworkscm.model.DescribeServersResponse;
 import software.amazon.awssdk.services.opsworkscm.model.InvalidStateException;
+import software.amazon.awssdk.services.opsworkscm.model.OpsWorksCmException;
 import software.amazon.awssdk.services.opsworkscm.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.opsworkscm.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.opsworkscm.model.Server;
@@ -33,7 +34,7 @@ public class CreateHandler extends BaseOpsWorksCMHandler {
         } catch (InvalidStateException e) {
             log.error(String.format("Service Side failure during create-server for %s.", this.model.getServerName()), e);
             return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InternalFailure, "Service Internal Failure");
-        } catch (ValidationException e) {
+        } catch (OpsWorksCmException e) {
             log.error(String.format("ValidationException during create-server for %s.", this.model.getServerName()), e);
             return ProgressEvent.failed(this.model, this.callbackContext, HandlerErrorCode.InvalidRequest, e.getMessage());
         } catch (Exception e) {


### PR DESCRIPTION
The `OpsWorksCmException "Cross-account pass role is not allowed."` caused an internal failure. This commits forwards it into the CFN stack events. Making failures easier to debug for customers and developers, without revealing any exceptions our API does not reveal already.

### Testing
* `mvn package`
* `pre-commit run --all-files`
