### PR TITLE
Fix ReadHandler NullPointer

### DIFF
--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ReadHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ReadHandler.java
@@ -23,7 +23,7 @@ public class ReadHandler extends BaseOpsWorksCMHandler {
 
         final DescribeServersResponse result;
         final String serverName = model.getPrimaryIdentifier().get(IDENTIFIER_KEY_SERVERNAME).toString();
-        callbackContext.incrementRetryTimes();
+        this.callbackContext.incrementRetryTimes();
 
         log.info(String.format("Calling Describe Servers for ServerName %s", serverName));
 


### PR DESCRIPTION
The ReadHandler was using an uninitialized paramter, causing a `NullPointerException`. Using the initialized corresponding field instead.

### Testing Done
* `mvn package`
* submitted code locally and tried ReadHandler with this template:
```
AWSTemplateFormatVersion: '2010-09-09'
Resources:
  MyChefServer:
    Type: AWS::OpsWorksCM::Server
    Properties:
      BackupRetentionCount: 12
      DisableAutomatedBackup: False
      Engine: 'ChefAutomate'
      EngineVersion: '2'
      EngineModel: 'Single'
      InstanceProfileArn: "arn:aws:iam::340308762637:instance-profile/aws-opsworks-cm-ec2-role2"
      InstanceType: 'm4.xlarge'
      PreferredBackupWindow: '08:00'
      PreferredMaintenanceWindow: 'Fri:08:00'
      ServiceRoleArn: "arn:aws:iam::340308762637:role/service-role/aws-opsworks-cm-service-role"
Outputs:
  Endpoint:
    Description: Server Endpoint
    Value: !GetAtt [MyChefServer, Endpoint]
  Arn:
    Description: Server Arn
    Value: !GetAtt [MyChefServer, Arn]
```