### PR TITLE
Add CreateServer and UpdateServer Canaries

### DIFF
--- a/aws-opsworkscm-server/canary-bundle/bootstrap.yaml
+++ b/aws-opsworkscm-server/canary-bundle/bootstrap.yaml
@@ -1,0 +1,62 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: IAM Resources for the AWS OpsWorks Managed Server.
+Resources:
+  CanaryInstanceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      #Name needs "aws-opsworks-cm-" as prefix
+      RoleName: "aws-opsworks-cm-CanaryInstanceRole"
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - arn:aws:iam::aws:policy/AWSOpsWorksCMInstanceProfileRole
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - "sts:AssumeRole"
+          Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+        Version: "2012-10-17"
+      Path: "/service-role/"
+  CanaryInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: "/"
+      Roles:
+      - {Ref: CanaryInstanceRole}
+      #Name needs "aws-opsworks-cm-" as prefix
+      InstanceProfileName: "aws-opsworks-cm-CanaryInstanceProfile"
+  CanaryServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      #Name needs "aws-opsworks-cm-" as prefix
+      RoleName: "aws-opsworks-cm-CanaryServiceRole"
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSOpsWorksCMServiceRole
+      AssumeRolePolicyDocument:
+        Statement:
+        - Action:
+          - "sts:AssumeRole"
+          Effect: "Allow"
+          Principal:
+            Service:
+            - "opsworks-cm.amazonaws.com"
+        Version: "2012-10-17"
+      Path: "/service-role/"
+Outputs:
+  CanaryInstanceRoleArn:
+    Description: Arn of the InstanceRole
+    Value: Fn::GetAtt [CanaryInstanceRole, Arn]
+    Export:
+      Name: "CanaryInstanceRoleArn"
+  CanaryInstanceProfileArn:
+    Description: Arn of the InstanceProfile
+    Value: Fn::GetAtt [CanaryInstanceProfile, Arn]
+    Export:
+      Name: "CanaryInstanceProfileArn"
+  CanaryServiceRoleArn:
+    Description: Arn of the ServiceRole
+    Value: Fn::GetAtt [CanaryServiceRole, Arn]
+    Export:
+      Name: "CanaryServiceRoleArn"

--- a/aws-opsworkscm-server/canary-bundle/canary/CanaryAutomate_001.yaml
+++ b/aws-opsworkscm-server/canary-bundle/canary/CanaryAutomate_001.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Canary template for OpsWorksCM::Server Create operation
+Resources:
+  OpsWorksCanaryServer:
+    Type: AWS::OpsWorksCM::Server
+    Properties:
+      BackupRetentionCount: 12
+      DisableAutomatedBackup: False
+      Engine: 'ChefAutomate'
+      EngineVersion: '2'
+      EngineModel: 'Single'
+      InstanceProfileArn:
+        Fn::ImportValue:
+          Fn::Sub: "CanaryInstanceProfileArn"
+      InstanceType: 'm4.large'
+      PreferredBackupWindow: '08:00'
+      PreferredMaintenanceWindow: 'Fri:08:00'
+      ServiceRoleArn:
+        Fn::ImportValue:
+          Fn::Sub: "CanaryServiceRoleArn"

--- a/aws-opsworkscm-server/canary-bundle/canary/CanaryAutomate_002.yaml
+++ b/aws-opsworkscm-server/canary-bundle/canary/CanaryAutomate_002.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Canary template for OpsWorksCM::Server Update operation
+Resources:
+  OpsWorksCanaryServer:
+    Type: AWS::OpsWorksCM::Server
+    Properties:
+      BackupRetentionCount: 6
+      DisableAutomatedBackup: True
+      Engine: 'ChefAutomate'
+      EngineVersion: '2'
+      EngineModel: 'Single'
+      InstanceProfileArn:
+        Fn::ImportValue:
+          Fn::Sub: "CanaryInstanceProfileArn"
+      InstanceType: 'm4.large'
+      PreferredBackupWindow: '05:00'
+      PreferredMaintenanceWindow: 'Wed:05:00'
+      ServiceRoleArn:
+        Fn::ImportValue:
+          Fn::Sub: "CanaryServiceRoleArn"

--- a/aws-opsworkscm-server/canary-bundle/canary_settings.yaml
+++ b/aws-opsworkscm-server/canary-bundle/canary_settings.yaml
@@ -1,0 +1,2 @@
+ConcurrentStackCount: 1
+Timeout: 28


### PR DESCRIPTION
Adding the template used for the canary. We decided to have a single canary, since our code path does not depend on any of the API's parameters. 

* `bootstrap.yaml` contains the prerequisite IAM roles (described in opsworks-cm docs). 
* `CanaryAutomate_001.yaml` contains what will be used for the "CanaryAutomate" canary Create call
* `CanaryAutomate_002.yaml` contains what will be used for the "CanaryAutomate" canary Update call

Using the same `canary_settings` as we used to. A timeout of 28 minutes and 1 canary at a time means at least 2 runs per hour. 3 DPs to alarm would mean 1.5 h until we noice a failure.

### Testing Done
* `mvn package`
* `pre-commit run --all-files`
* manually ran the canary flow:
```
aws cloudformation create-stack --stack-name bootstrap --template-body file://canary-bundle/bootstrap.yaml --region us-east-1 --capabilities CAPABILITY_NAMED_IAM
aws cloudformation create-stack --stack-name testCanary --template-body file://canary-bundle/canary/CanaryAutomate_001.yaml --region us-east-1
aws cloudformation update-stack --stack-name testCanary --template-body file://canary-bundle/canary/CanaryAutomate_002.yaml --region us-east-1
```