### PR TITLE
Moving fields into context parameter

### DIFF
--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/InvocationContext.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/InvocationContext.java
@@ -1,0 +1,13 @@
+package software.amazon.opsworkscm.server;
+
+import lombok.Data;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.opsworkscm.server.utils.LoggerWrapper;
+
+@Data
+public class InvocationContext {
+    ResourceModel model;
+    ResourceModel oldModel;
+    CallbackContext callbackContext;
+    ResourceHandlerRequest<ResourceModel> request;
+}

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ListHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ListHandler.java
@@ -17,9 +17,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
 
     private static final int NO_CALLBACK_DELAY = 0;
 
-    CallbackContext callbackContext;
     LoggerWrapper log;
-    ResourceHandlerRequest<ResourceModel> request;
     ClientWrapper client;
 
     @Override
@@ -31,8 +29,8 @@ public class ListHandler extends BaseHandler<CallbackContext> {
 
         this.log = new LoggerWrapper(logger);
 
-        final OpsWorksCmClient opsWorksCmClientclient = ClientBuilder.getClient();
-        this.client = new ClientWrapper(opsWorksCmClientclient, request.getDesiredResourceState(), request.getPreviousResourceState(), proxy, log);
+        final OpsWorksCmClient opsWorksCmClient = ClientBuilder.getClient();
+        this.client = new ClientWrapper(opsWorksCmClient, request.getDesiredResourceState(), request.getPreviousResourceState(), proxy, log);
 
         log.info("Calling Describe Servers with no ServerName");
 

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ReadHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ReadHandler.java
@@ -19,27 +19,27 @@ public class ReadHandler extends BaseOpsWorksCMHandler {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        initialize(proxy, request, callbackContext, logger);
+        InvocationContext context = initializeContext(proxy, request, callbackContext, logger);
 
         final DescribeServersResponse result;
-        final String serverName = model.getPrimaryIdentifier().get(IDENTIFIER_KEY_SERVERNAME).toString();
-        this.callbackContext.incrementRetryTimes();
+        final String serverName = context.getModel().getPrimaryIdentifier().get(IDENTIFIER_KEY_SERVERNAME).toString();
+        context.getCallbackContext().incrementRetryTimes();
 
         log.info(String.format("Calling Describe Servers for ServerName %s", serverName));
 
         try {
             result = client.describeServer(serverName);
             Server server = result.servers().get(0);
-            addDescribeServerResponseAttributes(server);
-            return ProgressEvent.defaultSuccessHandler(model);
+            addDescribeServerResponseAttributes(context, server);
+            return ProgressEvent.defaultSuccessHandler(context.getModel());
         } catch (final software.amazon.awssdk.services.opsworkscm.model.ResourceNotFoundException e) {
             log.error(String.format("Server %s was not found.", serverName), e);
             throw new ResourceNotFoundException(String.format("Server %s was not found.", serverName), e.getMessage());
         }
     }
 
-    private void addDescribeServerResponseAttributes(final Server server) {
-        model.setEndpoint(server.endpoint());
-        model.setArn(server.serverArn());
+    private void addDescribeServerResponseAttributes(InvocationContext context, final Server server) {
+        context.getModel().setEndpoint(server.endpoint());
+        context.getModel().setArn(server.serverArn());
     }
 }

--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/UpdateHandler.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/UpdateHandler.java
@@ -18,38 +18,38 @@ public class UpdateHandler extends BaseOpsWorksCMHandler {
             final CallbackContext callbackContext,
             final Logger logger) {
 
-        initialize(proxy, request, callbackContext, logger);
+        InvocationContext context = initializeContext(proxy, request, callbackContext, logger);
 
         try {
-            if (!this.callbackContext.isUpdateTagComplete()) {
-                return updateTags();
+            if (!context.getCallbackContext().isUpdateTagComplete()) {
+                return updateTags(context);
             }
-            if (!this.callbackContext.isUpdateServerComplete()) {
-                return updateServer();
+            if (!context.getCallbackContext().isUpdateServerComplete()) {
+                return updateServer(context);
             }
-            return ProgressEvent.defaultSuccessHandler(this.model);
+            return ProgressEvent.defaultSuccessHandler(context.getModel());
         } catch (ResourceNotFoundException e) {
-            log.error(String.format("ResourceNotFoundException during update of server %s, with message %s", this.model.getServerName(), e.getMessage()), e);
+            log.error(String.format("ResourceNotFoundException during update of server %s, with message %s", context.getModel().getServerName(), e.getMessage()), e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotFound);
         } catch (InvalidStateException e) {
-            log.error(String.format("InvalidStateException during update of server %s, with message %s", this.model.getServerName(), e.getMessage()), e);
+            log.error(String.format("InvalidStateException during update of server %s, with message %s", context.getModel().getServerName(), e.getMessage()), e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotUpdatable);
         } catch (ValidationException e) {
-            log.error(String.format("ValidationException during update of server %s, with message %s", this.model.getServerName(), e.getMessage()), e);
+            log.error(String.format("ValidationException during update of server %s, with message %s", context.getModel().getServerName(), e.getMessage()), e);
             return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InvalidRequest);
         }
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> updateTags() {
+    private ProgressEvent<ResourceModel, CallbackContext> updateTags(InvocationContext context) {
         client.untagServer();
         client.tagServer();
-        callbackContext.setUpdateTagComplete(true);
-        return ProgressEvent.defaultInProgressHandler(callbackContext, NO_CALLBACK_DELAY, model);
+        context.getCallbackContext().setUpdateTagComplete(true);
+        return ProgressEvent.defaultInProgressHandler(context.getCallbackContext(), NO_CALLBACK_DELAY, context.getModel());
     }
 
-    private ProgressEvent<ResourceModel, CallbackContext> updateServer() {
+    private ProgressEvent<ResourceModel, CallbackContext> updateServer(InvocationContext context) {
         client.updateServer();
-        callbackContext.setUpdateServerComplete(true);
-        return ProgressEvent.defaultInProgressHandler(callbackContext, NO_CALLBACK_DELAY, model);
+        context.getCallbackContext().setUpdateServerComplete(true);
+        return ProgressEvent.defaultInProgressHandler(context.getCallbackContext(), NO_CALLBACK_DELAY, context.getModel());
     }
 }


### PR DESCRIPTION
In lambda the handler constructor is only called for the first invocation. All fields are static and are shared across multiple invocations. To stop context information from leaking into the wrong invocation, moving all context related information into a InvocationContext object, that gets passed between method calls.

Did not edit the tests, since the functionality does not change.

### Testing Done
* `mvn package`
