### PR TITLE
Fix GetAtt formatting in canary bootstrap template

### DIFF
--- a/aws-opsworkscm-server/canary-bundle/bootstrap.yaml
+++ b/aws-opsworkscm-server/canary-bundle/bootstrap.yaml
@@ -47,16 +47,19 @@ Resources:
 Outputs:
   CanaryInstanceRoleArn:
     Description: Arn of the InstanceRole
-    Value: Fn::GetAtt [CanaryInstanceRole, Arn]
+    Value:
+      Fn::GetAtt: [CanaryInstanceRole, Arn]
     Export:
       Name: "CanaryInstanceRoleArn"
   CanaryInstanceProfileArn:
     Description: Arn of the InstanceProfile
-    Value: Fn::GetAtt [CanaryInstanceProfile, Arn]
+    Value:
+      Fn::GetAtt: [CanaryInstanceProfile, Arn]
     Export:
       Name: "CanaryInstanceProfileArn"
   CanaryServiceRoleArn:
     Description: Arn of the ServiceRole
-    Value: Fn::GetAtt [CanaryServiceRole, Arn]
+    Value:
+      Fn::GetAtt: [CanaryServiceRole, Arn]
     Export:
       Name: "CanaryServiceRoleArn"


### PR DESCRIPTION
The format of the `Fn::GetAtt` function was wrong. Fixing it.

### Testing Done
* `mvn package`
* tried template manually and checked outputs
