### PR TITLE
Duplicate existing canary for more DPs

### DIFF
--- a/aws-opsworkscm-server/canary-bundle/canary_settings.yaml
+++ b/aws-opsworkscm-server/canary-bundle/canary_settings.yaml
@@ -1,2 +1,2 @@
-ConcurrentStackCount: 1
+ConcurrentStackCount: 2
 Timeout: 28


### PR DESCRIPTION
Double the amount of canaries run, to increase the DPs our alarms have.

### Testing done
* `mvn package`