### PR TITLE
Upgrade aws-cloudformation-rpdk-java-plugin to 2.0.0

### DIFF
--- a/aws-opsworkscm-server/.rpdk-config
+++ b/aws-opsworkscm-server/.rpdk-config
@@ -10,6 +10,7 @@
             "amazon",
             "opsworkscm",
             "server"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-opsworkscm-server/pom.xml
+++ b/aws-opsworkscm-server/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.5</version>
+            <version>2.0.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/sdk-core -->


### PR DESCRIPTION
*Description of changes:*
- RPDK version 2.0 has increased resource payload limit, from 8 kb to 6 mb, so upgrading the version for OpsWorksCM::Server resource

*Testing*
- mvn package
- pre-commit run --all-files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
