### PR TITLE
Do not call UntagResource without keys

### DIFF
--- a/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ClientWrapper.java
+++ b/aws-opsworkscm-server/src/main/java/software/amazon/opsworkscm/server/ClientWrapper.java
@@ -159,12 +159,17 @@ public class ClientWrapper {
         if (oldModel.getTags() == null) {
             return null;
         }
+
         oldTags = oldModel.getTags().stream().map(t -> t.getKey());
         if (model.getTags() == null) {
             tagKeyDiff = oldTags.collect(Collectors.toList());
         } else {
             List<String> newTagKeys = model.getTags().stream().map(t -> t.getKey()).collect(Collectors.toList());
             tagKeyDiff = oldTags.filter(k -> !newTagKeys.contains(k)).collect(Collectors.toList());
+        }
+
+        if (tagKeyDiff.size() == 0) {
+            return null;
         }
 
         return UntagResourceRequest.builder()

--- a/aws-opsworkscm-server/src/test/java/software/amazon/opsworkscm/server/UpdateHandlerTest.java
+++ b/aws-opsworkscm-server/src/test/java/software/amazon/opsworkscm/server/UpdateHandlerTest.java
@@ -271,8 +271,30 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void tagsAreDiffedOnUntagNoPreviousTags() {
-        verifyUntagDiff(ImmutableList.of("keepMe", "keepMe2"), Collections.emptyList());
+    public void noUntagOnNoPreviousTags() {
+        List<Tag> newTags = new ArrayList<>();
+        List<Tag> oldTags = new ArrayList<>();
+        newTags.add(Tag.builder().key("keepMe").value("").build());
+        request.setDesiredResourceState(ResourceModel.builder().tags(newTags).build());
+        request.setPreviousResourceState(ResourceModel.builder().tags(oldTags).build());
+        assertStabilizeSuccess(request);
+        ArgumentCaptor<AwsRequest> accountArgumentCaptor = forClass(AwsRequest.class);
+        verify(proxy, atLeastOnce()).injectCredentialsAndInvokeV2(accountArgumentCaptor.capture(), any());
+        Optional<AwsRequest> request = accountArgumentCaptor.getAllValues().stream().filter(s -> s.getClass().equals(UntagResourceRequest.class)).findFirst();
+        assertThat(request.isPresent()).isFalse();
+    }
+
+    @Test
+    public void noUntagOnNoTagsAtAll() {
+        List<Tag> newTags = new ArrayList<>();
+        List<Tag> oldTags = new ArrayList<>();
+        request.setDesiredResourceState(ResourceModel.builder().tags(newTags).build());
+        request.setPreviousResourceState(ResourceModel.builder().tags(oldTags).build());
+        assertStabilizeSuccess(request);
+        ArgumentCaptor<AwsRequest> accountArgumentCaptor = forClass(AwsRequest.class);
+        verify(proxy, atLeastOnce()).injectCredentialsAndInvokeV2(accountArgumentCaptor.capture(), any());
+        Optional<AwsRequest> request = accountArgumentCaptor.getAllValues().stream().filter(s -> s.getClass().equals(UntagResourceRequest.class)).findFirst();
+        assertThat(request.isPresent()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Before, our logic diffed the tags in the update call, but would not make a difference if there was nothing to untag. In any case a UntagResource would be invoked, causing a 400 because "No tags passed".

### Testing Done
* mvn package
* made an E2E update call without tags
