### PR TITLE
AWS::OpsWorksCM::Server.BackupRetentionCount minimum integer constraint instead of minLength

### DIFF
--- a/aws-opsworkscm-server/aws-opsworkscm-server.json
+++ b/aws-opsworkscm-server/aws-opsworkscm-server.json
@@ -97,7 +97,7 @@
     },
     "BackupRetentionCount": {
       "type": "integer",
-      "minLength": 1
+      "minimum": 1
     },
     "Id": {
       "type": "string",


### PR DESCRIPTION
@avinash-karthik @bjollans @eemreavci @srikailash
[issue for `cfn validate` to catch these automatically](https://github.com/aws-cloudformation/cloudformation-cli/issues/414)
[`AWS::OpsWorksCM::Server.BackupRetentionCount`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opsworkscm-server.html#cfn-opsworkscm-server-backupretentioncount)
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-opsworkscm/pull/16#discussion_r466092042
[JSON Schema numeric ranges](https://json-schema.org/understanding-json-schema/reference/numeric.html#range)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
